### PR TITLE
fix: change time.now to ctx.blocktime

### DIFF
--- a/x/registry/keeper/msg_server_register_domain.go
+++ b/x/registry/keeper/msg_server_register_domain.go
@@ -2,7 +2,6 @@ package keeper
 
 import (
 	"context"
-	"time"
 
 	"mycel/x/registry/types"
 
@@ -17,7 +16,7 @@ func (k msgServer) RegisterDomain(goCtx context.Context, msg *types.MsgRegisterD
 		return nil, err
 	}
 
-	currentTime := time.Now().In(time.UTC)
+	currentTime := ctx.BlockTime()
 	expirationDate := currentTime.AddDate(int(msg.RegistrationPeriodInYear), 0, 0)
 
 	domain := types.Domain{


### PR DESCRIPTION
`time.Now()`を使うとそれぞれのvalidatorで計算する値が異なってしまうため、
```
ERR CONSENSUS FAILURE!!! err="+2/3 committed an invalid block: wrong Block.Header.AppHash.  Expected 968F7F14B9CC5977B7AB1489FEBE52E7B4425BCD30829EB82A6464293C044261, got 8F100F181CF01A6EDDB46177E1BFEC7FA2DAC6676BFB5E09DFF02386509FDDCA"
```
が発生する。

代わりに、`ctx.BlockTime()`を使う。